### PR TITLE
Expose underlying MQTT client

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ export class AppService implements OnModuleDestroy {
   ) {}
 
   onModuleDestroy(): Promise<void> {
-    // Convert the connection closed callback to a promise
-    return util.promisify(this.mqttClient.end)();
+    return this.mqttClient.endAsync();
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -135,6 +135,31 @@ export class TestService {
 }
 ```
 
+### Closing the underlying MQTT connection
+
+In some cases it's desirable to explicitly close the underlying MQTT connection on application shutdown. This allows the
+client to ack in-flight messages and may be useful to fix some integration test issues.
+
+In order to close the connection, inject the underlying mqtt client with the `MQTT_CLIENT_INSTANCE` token. Use the
+`onModuleDestroy` lifecycle event to call the `end` method on the mqtt client instance as shown below.
+
+```typescript
+
+@Injectable()
+export class AppService implements OnModuleDestroy {
+  constructor(
+    @Inject(MQTT_CLIENT_INSTANCE) private readonly client: Client,
+  ) {}
+
+  onModuleDestroy(): Promise<void> {
+    // Convert the connection closed callback to a promise
+    return util.promisify(this.mqttClient.end)();
+  }
+}
+```
+
+Depending on use-case you might also need to enable the [application shutdown hooks](https://docs.nestjs.com/fundamentals/lifecycle-events#application-shutdown).
+
 ## Emqtt Compatible
 
 nest-mqtt support emq shared subscription

--- a/src/mqtt.module.ts
+++ b/src/mqtt.module.ts
@@ -5,11 +5,11 @@ import { MqttExplorer } from './mqtt.explorer';
 import { DiscoveryModule } from '@nestjs/core';
 import { createLoggerProvider, createOptionProviders } from './options.provider';
 import { MqttModuleAsyncOptions, MqttModuleOptions } from './mqtt.interface';
-import { MQTT_OPTION_PROVIDER } from './mqtt.constants';
+import { MQTT_CLIENT_INSTANCE, MQTT_OPTION_PROVIDER } from './mqtt.constants';
 
 @Module({
   imports: [DiscoveryModule],
-  exports: [MqttService],
+  exports: [MqttService, MQTT_CLIENT_INSTANCE],
 })
 export class MqttModule {
   public static forRootAsync(options: MqttModuleAsyncOptions): DynamicModule {


### PR DESCRIPTION
Exposes the underlying MQTT client allowing the user to properly close the connection(ack in-flight messages), before disconnecting. 

This is the same problem as in [issue 15](https://github.com/microud/nest-mqtt/issues/15) in the original microud/nest-mqtt repo with the solution from [pull-request 17](https://github.com/microud/nest-mqtt/pull/17).